### PR TITLE
Style: added support for sass 2.0.0

### DIFF
--- a/src/styles/core/tools/_strip-unit.scss
+++ b/src/styles/core/tools/_strip-unit.scss
@@ -4,7 +4,7 @@
 
 @function strip-unit($number) {
   @if type-of($number) == 'number' and not unitless($number) {
-    @return $number / ($number * 0 + 1);
+    @return calc($number / ($number * 0 + 1));
   }
   @return $number;
 }


### PR DESCRIPTION
This will address dart sass Depreciation Warning: "Using / for division outside of calc() is depreciated and will be remove din Dart Sass 2.0.0"